### PR TITLE
Fix contains() for undefined argument

### DIFF
--- a/enums.js
+++ b/enums.js
@@ -6,7 +6,7 @@
         });
         return target;
     }
-    
+
     function Symbol(name, props) {
         this.name = name;
         if (props) {
@@ -46,7 +46,7 @@
         );
     }
     Enum.prototype.contains = function(sym) {
-        if (! sym instanceof Symbol) return false;
+        if (!(sym instanceof Symbol)) return false;
         return this[sym.name] === sym;
     }
     exports.Enum = Enum;

--- a/enums.spec.js
+++ b/enums.spec.js
@@ -17,6 +17,7 @@ describe("Enum", function() {
         var fruit = new enums.Enum("apple", "banana");
         expect(color.contains(color.red)).toBeTruthy();
         expect(color.contains(fruit.apple)).toBeFalsy();
+        expect(color.contains(undefined)).toBeFalsy();
     });
 });
 


### PR DESCRIPTION
myEnum.contains(undefined) would throw an exception rather than return false, because the ! operator binds more tightly than instanceof 
